### PR TITLE
configure for usage with managed cockroach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kvb rad 
 
-The application polls the position of the kvb bikes every minute and saves it in a [mysql](https://www.mysql.com/) database. It uses a selfhosted [graphhopper](https://www.graphhopper.com/) server to  calculate the shortest route between the two positions of a bike if it was moved between two polls. To view the data you can use the web application [kvb-rad-ui](https://github.com/CrowdSalat/kvb-rad-ui).
+The application polls the position of the kvb bikes every minute and saves it in a [managed cockroachdb](https://cockroachlabs.cloud) database. It uses a selfhosted [graphhopper](https://www.graphhopper.com/) server to  calculate the shortest route between the two positions of a bike if it was moved between two polls. To view the data you can use the web application [kvb-rad-ui](https://github.com/CrowdSalat/kvb-rad-ui).
 
 ## commands
 
@@ -11,6 +11,16 @@ The application polls the position of the kvb bikes every minute and saves it in
 - Start application with docker-compose: `docker-compose up -d`
 - Start application with headless docker-compose: `docker-compose --file ./docker-compose-headless.yml up -d`
 - Stop application: `docker-compose down`
+
+
+Start with docker-compose
+```
+// with mysql and ui
+docker-compose -f docker-compose.yml up
+
+// with mysql and without ui
+docker-compose -f docker-compose-headless.yml up
+```
 
 Start application with docker: 
 

--- a/docker-compose-headless.yml
+++ b/docker-compose-headless.yml
@@ -6,6 +6,8 @@ services:
     restart: always
     ports:
       - "127.0.0.1:9090:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: mysql
     depends_on:
       - database
   database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     restart: always
     ports:
       - "127.0.0.1:9090:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: mysql
     depends_on:
       - database
   kvb-rad-ui:

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -7,10 +7,10 @@ api.graphhopper.route.url=http://localhost:8989/route
 ## spring properties
 
 # database
-spring.jpa.database=POSTGRESQL
-spring.datasource.url=jdbc:postgresql://free-tier13.aws-eu-central-1.cockroachlabs.cloud:26257/defaultdb?options=--cluster%3Dcrowdsalat-1065&sslmode=verify-full
-spring.datasource.username=crowdsalat
-spring.datasource.password=<WORKS_WHEN_RIGHT_PW>
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://kvb-rad-mysql:3306/kvbbike-db
+spring.datasource.username=root
+spring.datasource.password=krautsalat
 
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ api.graphhopper.route.url=http://localhost:8989/route
 
 # database
 spring.jpa.database=POSTGRESQL
-spring.datasource.url=jdbc:postgresql://free-tier13.aws-eu-central-1.cockroachlabs.cloud:26257/defaultdb?options=--cluster%3Dcrowdsalat-1065&sslmode=verify-full
+spring.datasource.url=jdbc:postgresql://free-tier13.aws-eu-central-1.cockroachlabs.cloud:26257/kvbbike-db?options=--cluster%3Dcrowdsalat-1065&sslmode=verify-full
 spring.datasource.username=crowdsalat
 spring.datasource.password=<WORKS_WHEN_RIGHT_PW>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,17 +1,20 @@
 ## custom properties
 
 api.nextbike.kvb.url=https://api.nextbike.net/maps/nextbike-live.json?city=14
-api.graphhopper.route.url=http://kvb-rad-graphhopper:8989/route
+api.graphhopper.route.url=http://localhost:8989/route
 
 
 ## spring properties
 
 # mysql
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://kvb-rad-mysql:3306/kvbbike-db
-spring.datasource.username=root
-spring.datasource.password=krautsalat
+spring.jpa.database=POSTGRESQL
+spring.datasource.url=jdbc:postgresql://free-tier13.aws-eu-central-1.cockroachlabs.cloud:26257/defaultdb?options=--cluster%3Dcrowdsalat-1065&sslmode=verify-full
+spring.datasource.username=crowdsalat
+spring.datasource.password=<WORKS_WHEN_RIGHT_PW>
 
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+
+spring.cloud.kubernetes.config.enableApi=false
+spring.cloud.kubernetes.secrets.enableApi=false


### PR DESCRIPTION
Works

- connection
- integration in k8s via helm chart
 - build newest version of graphhopper and puzsh to dokcerhub
- deploy graphopper to k8s
 - add sealed secret for cockroach password
- configure kvb-backend to use graphopper and cockroach 
 -  0.5.0-pre als image gebaut und verbindung getestet.

TODO
- Problem: Postgres Root cert fehlt im image. muss zum ausführenden User kopiert werden was leider der root ist im falls vom kvb-radc containers. Download anleitung für cert ifndet sich bei connect in cockraoch
- backup mysql and upload dump to s3
- load dump into cockraoch db from s3
- restart kvb-backend with the table which was backedup from mysql